### PR TITLE
qcacld-2.0: Fix buffer overflow in WLANSAP_Set_WPARSNIes()

### DIFF
--- a/drivers/staging/prima/CORE/HDD/src/wlan_hdd_hostapd.c
+++ b/drivers/staging/prima/CORE/HDD/src/wlan_hdd_hostapd.c
@@ -2429,6 +2429,13 @@ static int iw_set_ap_genie(struct net_device *dev,
         return 0;
     }
 
+    if (wrqu->data.length > DOT11F_IE_RSN_MAX_LEN) {
+       VOS_TRACE(VOS_MODULE_ID_HDD, VOS_TRACE_LEVEL_ERROR,
+               "%s: WPARSN Ie input length is more than max[%d]", __func__,
+                wrqu->data.length);
+       return -EINVAL;
+    }
+
     switch (genie[0]) 
     {
         case DOT11F_EID_WPA: 


### PR DESCRIPTION
Currently In WLANSAP_Set_WPARSNIes() the parameter WPARSNIEsLen
is user-controllable and never validates which uses as the length
for a memory copy. This enables user-space applications to corrupt
heap memory and potentially crash the kernel.

Fix is to validate the WPARSNIes length to its max before use as the
length for a memory copy.

CAF-Change-Id: I7aff731aeae22bfd84beb955439a799abef37f68
CRs-Fixed: 1102648

CVE-2017-6424

Change-Id: Ia3ac5038e51d1548627afe6685c82cf0fd850f08