### PR TITLE
ASoC: msm: qdsp6v2: fix invalid access to memory

### DIFF
--- a/sound/soc/msm/qdsp6v2/msm-pcm-q6-v2.c
+++ b/sound/soc/msm/qdsp6v2/msm-pcm-q6-v2.c
@@ -119,7 +119,7 @@ static void event_handler(uint32_t opcode,
 		wake_up(&the_locks.write_wait);
 		if (!atomic_read(&prtd->start))
 			break;
-		if (!prtd->mmap_flag)
+		if (!prtd->mmap_flag || prtd->reset_event)
 			break;
 		if (q6asm_is_cpu_buf_avail_nolock(IN,
 				prtd->audio_client,


### PR DESCRIPTION
During SSR, write done events are dispatched to
PCM driver as part of cleanup by DSP, and driver
is not supposed to send any write commands further.
Avoid sending write commands incase of SSR is in
progress.

Change-Id: Idfdaa04c7e7dde8482269bf64317aac423b807b3
Signed-off-by: Laxminath Kasam <lkasam@codeaurora.org>